### PR TITLE
Fix double attempt at patching for FasterShufflePatch

### DIFF
--- a/src/FasterShufflePatch.cs
+++ b/src/FasterShufflePatch.cs
@@ -29,6 +29,9 @@ public class FasterShufflePatch
             return normalTime *  GetMultiplier();
         }
         
+        
+        //Harmony is trying to apply the patch twice for some reason
+        //Using a Prepare method to prevent it
         private static bool didPatch = false;
 
         static bool Prepare(MethodBase original)


### PR DESCRIPTION
For some reason, Harmony was trying to apply the patch twice and naturally couldn't find a match in th IL code once it was applied once.
Fixed using a Prepare method, but admittedly figuring out the reason it even does that would be better