### PR TITLE
Reorder special card rewards to after normal card rewards

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Successor of the StS1 mod with the same name. This is a compilation of small qua
 - Make's the Pael's Eye relic look at the mouse cursor (mangochicken)
 - Adds an indicator to attacks when pen nib is active (book)
 - Adds a preview of how much gold you will have after a purchase (Ind-E)
+- Reorders combat rewards to stop special card rewards like Thieving Hopper from covering the normal card reward when clicked in default order (kiooeht)
 
 ## Installation
 Make a folder called `mods` in the same directory as your sts2.exe `Steam\steamapps\common\Slay the Spire 2` and unzip the contents of the release (once available) into that folder or a subdirectory within that folder.

--- a/src/SpecialCardRewardOrder.cs
+++ b/src/SpecialCardRewardOrder.cs
@@ -1,0 +1,19 @@
+﻿using HarmonyLib;
+using MegaCrit.Sts2.Core.Rewards;
+
+namespace MintySpire2;
+
+/**
+ * Changes the order of combat rewards so "special" card rewards (Thieving Hopper and Lantern Key) are below normal card
+ * rewards. This is done because clicking rewards in their normal order causes a long delay while you wait for the
+ * special card to stop covering up the middle card of the card reward.
+ */
+[HarmonyPatch(typeof(SpecialCardReward), nameof(SpecialCardReward.RewardsSetIndex), MethodType.Getter)]
+static class SpecialCardRewardOrder
+{
+    [HarmonyPostfix]
+    static void AfterNormalCardRewards(SpecialCardReward __instance, ref int __result)
+    {
+        __result = 6;
+    }
+}


### PR DESCRIPTION
This is done because clicking rewards in their normal order causes a long delay while you wait for the special card to stop covering up the middle card of the card reward.

<img width="680" height="871" alt="image" src="https://github.com/user-attachments/assets/224c2ec7-d965-48a9-a1fe-1cca422a9a5a" />
