### PR TITLE
Put Bowler Hat before gold

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,9 @@ Successor of the StS1 mod with the same name. This is a compilation of small qua
 - Heal preview above the rest button at rest sites
 - Adds a preview of how much gold you will have after a purchase (Ind-E)
 - Show ascenscion effects when hovering the character portrait in the top bar (kiooeht)
-- Reorders combat rewards to stop special card rewards like Thieving Hopper from covering the normal card reward when clicked in default order (kiooeht)
+- Reorders combat rewards to:
+    - Stop special card rewards like Thieving Hopper from covering the normal card reward when clicked in default order (kiooeht)
+    - Put the Bowler Hat relic before the gold reward so you don't autopilot and miss the bonus gold (mangochicken)
 - Make torches clickable to extiguish and light them (cany0udance)
 - Make's the Pael's Eye relic look at the mouse cursor (mangochicken)
 

--- a/src/BowlerHatBeforeGold.cs
+++ b/src/BowlerHatBeforeGold.cs
@@ -1,0 +1,21 @@
+using HarmonyLib;
+using MegaCrit.Sts2.Core.Models.Relics;
+using MegaCrit.Sts2.Core.Rewards;
+
+namespace MintySpire2;
+/**
+ * By Mangochicken.
+ * Moves Bowler Hat before the gold reward after combat,
+ * so you don't miss the 25% extra gold in the combat you obtain it
+ */
+[HarmonyPatch(typeof(RelicReward), nameof(RelicReward.RewardsSetIndex), methodType: MethodType.Getter)]
+public static class BowlerHatBeforeGold
+{
+    [HarmonyPostfix]
+    static void BeforeGold(RelicReward __instance, ref int __result)
+    {
+        // potentially split into unique config
+        if (Config.ChangeRewardOrder && __instance.Relic is BowlerHat)
+            __result = 0;
+    }
+}


### PR DESCRIPTION
Does what it says, puts specifically Bowler Hat's reward before the gold reward(s) in the combat reward list

Feel free to edit the readme back to the previous format if that's better, I figured having the two reward changes in the same place was appropriate. 
Also willing to change the implementation to use it's own config option if they should be decoupled