### PR TITLE
Fix method reference for CrimsonMantlePower in TwoAmountPower.cs

### DIFF
--- a/src/combat/TwoAmountPowers.cs
+++ b/src/combat/TwoAmountPowers.cs
@@ -179,7 +179,7 @@ static class TwoAmountPowers
                 typeof(PaleBlueDotPower).Method(nameof(PaleBlueDotPower.ModifyHandDraw)),
                 typeof(ToricToughnessPower).Method(nameof(ToricToughnessPower.SetBlock)),
                 typeof(InfernoPower).Method(nameof(InfernoPower.IncrementSelfDamage)),
-                typeof(CrimsonMantlePower).Method(nameof(InfernoPower.IncrementSelfDamage)),
+                typeof(CrimsonMantlePower).Method(nameof(CrimsonMantlePower.IncrementSelfDamage)),
             ];
         }
 


### PR DESCRIPTION
Fixes a typo in the `CrimsonMantlePower.IncrementSelfDamage` hook target.