### PR TITLE
Fix wither end turn damage

### DIFF
--- a/src/combat/SummedIncomingDamageRender.cs
+++ b/src/combat/SummedIncomingDamageRender.cs
@@ -6,6 +6,7 @@ using MegaCrit.Sts2.Core.Entities.Cards;
 using MegaCrit.Sts2.Core.Entities.Creatures;
 using MegaCrit.Sts2.Core.Entities.Players;
 using MegaCrit.Sts2.Core.Localization.DynamicVars;
+using MegaCrit.Sts2.Core.Models.Cards;
 using MegaCrit.Sts2.Core.Models.Powers;
 using MegaCrit.Sts2.Core.MonsterMoves.Intents;
 using MegaCrit.Sts2.Core.Nodes.Combat;
@@ -171,6 +172,16 @@ public static class SummedIncomingDamageRender
     }
 
     private static int incomingCardDamage = 0;
+
+    private static void RefreshIncomingCardDamage(Player player)
+    {
+        var newInc = GetIncomingCardDamage(player);
+        if (newInc == incomingCardDamage)
+            return;
+
+        incomingCardDamage = newInc;
+        ValidBars.ForEachLive(RefreshVisibilityAndText);
+    }
     
     private static int GetIncomingCardDamage(Player player)
     {
@@ -188,8 +199,7 @@ public static class SummedIncomingDamageRender
                 continue;
 
             // Ignoring HP loss cards here
-            if(card.DynamicVars.ContainsKey("Damage"))
-                totalDamage += card.DynamicVars.Damage.IntValue;
+            totalDamage += card.DynamicVars.Values.OfType<DamageVar>().Sum(cvar => cvar.IntValue);
         }
 
         return totalDamage;
@@ -208,14 +218,21 @@ public static class SummedIncomingDamageRender
         {
             var player = LocalContext.GetMe(RunManager.Instance.State);
             if (player?.PlayerCombatState == null) return;
-            
-            var newInc = GetIncomingCardDamage(player);
-            if (newInc != incomingCardDamage)
-            {
-                incomingCardDamage = newInc;
-                ValidBars.ForEachLive(RefreshVisibilityAndText);
-            }
+
+            RefreshIncomingCardDamage(player);
         }
+    }
+
+    [HarmonyPostfix]
+    [HarmonyPatch(typeof(Wither), nameof(Wither.FakeUpgrade))]
+    private static void CatchWitherFakeUpgrade(Wither __instance)
+    {
+        if (!Config.ShowIncomingDamage || __instance.Pile is not { Type: PileType.Hand }) return;
+
+        var player = LocalContext.GetMe(RunManager.Instance.State);
+        if (player?.PlayerCombatState == null || __instance.Owner != player) return;
+
+        RefreshIncomingCardDamage(player);
     }
 
     /// <summary>

--- a/src/combat/SummedIncomingDamageRender.cs
+++ b/src/combat/SummedIncomingDamageRender.cs
@@ -5,7 +5,9 @@ using MegaCrit.Sts2.Core.Context;
 using MegaCrit.Sts2.Core.Entities.Cards;
 using MegaCrit.Sts2.Core.Entities.Creatures;
 using MegaCrit.Sts2.Core.Entities.Players;
+using MegaCrit.Sts2.Core.Hooks;
 using MegaCrit.Sts2.Core.Localization.DynamicVars;
+using MegaCrit.Sts2.Core.Models;
 using MegaCrit.Sts2.Core.Models.Cards;
 using MegaCrit.Sts2.Core.Models.Powers;
 using MegaCrit.Sts2.Core.MonsterMoves.Intents;
@@ -199,10 +201,31 @@ public static class SummedIncomingDamageRender
                 continue;
 
             // Ignoring HP loss cards here
-            totalDamage += card.DynamicVars.Values.OfType<DamageVar>().Sum(cvar => cvar.IntValue);
+            totalDamage += card.DynamicVars.Values.OfType<DamageVar>().Sum(cvar => GetModifiedIncomingCardDamage(player, card, cvar));
         }
 
         return totalDamage;
+    }
+
+    private static int GetModifiedIncomingCardDamage(Player player, CardModel card, DamageVar damageVar)
+    {
+        var creature = player.Creature;
+        if (creature.CombatState == null)
+            return damageVar.IntValue;
+
+        var damage = Hook.ModifyDamage(
+            player.RunState,
+            creature.CombatState,
+            creature,
+            creature,
+            damageVar.BaseValue,
+            damageVar.Props,
+            card,
+            ModifyDamageHookType.All,
+            CardPreviewMode.None,
+            out _);
+
+        return Math.Max(0, (int)damage);
     }
     
     /// <summary>
@@ -260,8 +283,9 @@ public static class SummedIncomingDamageRender
         // Constrict power
         incomingDamage += creature.GetPower<ConstrictPower>()?.Amount ?? 0;
         
-        // End turn self damage cards (updated when the hand changes)
-        incomingDamage += incomingCardDamage;
+        // End turn self damage cards can be affected by current powers.
+        if (creature.Player != null)
+            incomingDamage += GetIncomingCardDamage(creature.Player);
 
         return incomingDamage;
     }


### PR DESCRIPTION
## Summary

Fix incoming end-turn damage previews for Wither and other end-turn self-damage cards.

## Details

- Wither created by Aeonglass can be upgraded after it has already been added to a pile.
  - `CardPile.InvokeContentsChanged` fires when the card enters the pile.
  - Aeonglass then matches the new Wither to the current upgrade count through `AfterCardGeneratedForCombat`, which calls `Wither.FakeUpgrade()`.
  - Because the card contents no longer change at that point, listening only to `InvokeContentsChanged` misses the updated damage.
  - This PR patches `Wither.FakeUpgrade()` directly so the incoming damage preview refreshes when a Wither in hand is upgraded.

- End-turn damage from cards in hand now uses the game’s normal damage modifier pipeline.
  - Previously the preview used raw `DamageVar` values, so effects like Intangible were not reflected.
  - This now calls `Hook.ModifyDamage(...)` with the player as both target and dealer, matching the actual self-damage behavior.
  - Incoming card damage is recalculated inside `CalculateIncomingDamage()` so power changes that affect damage are reflected when the health bar refreshes.
