### PR TITLE
Rename (and move) the main mod file to avoid mod conflicts

### DIFF
--- a/src/MintySpire2Mod.cs
+++ b/src/MintySpire2Mod.cs
@@ -7,7 +7,7 @@ using MintySpire2.util;
 namespace MintySpire2;
 
 [ModInitializer(nameof(Initialize))]
-public partial class MainFile : Node
+public partial class MintySpire2Mod : Node
 {
     public const string ModId = "MintySpire2"; //At the moment, this is used only for the Logger and harmony names.
 

--- a/src/jokes/PaelsEyePatch.cs
+++ b/src/jokes/PaelsEyePatch.cs
@@ -25,7 +25,7 @@ public class PaelsLookingEyePatch()
                 return eye;
             }
             else {
-                MainFile.Logger.Info("Oh my god its broken again");
+                MintySpire2Mod.Logger.Info("Oh my god its broken again");
             }
 
             return null;


### PR DESCRIPTION
Currently other mods that still have a MainFile.cs in the root folder will conflict on load, only the first that shares this issue will load correctly. This should prevent any future issues with Minty2 (I hope) (maybe)