### PR TITLE
fix: Fix two-amount power refresh after v0.108.0 update

### DIFF
--- a/MintySpire2Code/combat/TwoAmountPowers.cs
+++ b/MintySpire2Code/combat/TwoAmountPowers.cs
@@ -7,7 +7,6 @@ using MegaCrit.Sts2.Core.Combat;
 using MegaCrit.Sts2.Core.Combat.History.Entries;
 using MegaCrit.Sts2.Core.Context;
 using MegaCrit.Sts2.Core.Hooks;
-using MegaCrit.Sts2.Core.Modding;
 using MegaCrit.Sts2.Core.Models;
 using MegaCrit.Sts2.Core.Models.Powers;
 using MegaCrit.Sts2.Core.Nodes.Combat;
@@ -20,7 +19,7 @@ namespace MintySpire2.MintySpire2Code.combat;
 /**
  * Credits to kiooeht, this displays a second amount for powers that require tracking multiple values.
  */
-/*[HarmonyPatch(typeof(NPower))]
+[HarmonyPatch(typeof(NPower))]
 static class TwoAmountPowers
 {
     private static readonly Dictionary<Type, Func<PowerModel, Amount2Data>> DisplaySecondAmount = new() {
@@ -32,7 +31,7 @@ static class TwoAmountPowers
         { typeof(PaleBlueDotPower), power => {
             // Displays X/5 as amount2 where X is cards played this turn
             var cardCount = CombatManager.Instance.History.CardPlaysFinished.Count(c =>
-                c.RoundNumber == power.CombatState.RoundNumber &&
+                c.HappenedThisTurn(power.Owner.CombatState) &&
                 c.CardPlay.Card.Owner == power.Owner.Player);
             var threshold = power.DynamicVars[PaleBlueDotPower.cardPlayThresholdKey].IntValue;
             return $"{cardCount}/{threshold}";
@@ -135,8 +134,8 @@ static class TwoAmountPowers
 
         var amount2Label = __instance.GetNode<MegaLabel>("Amount2Label");
         // If ITwoAmountPower exists, let BaseLib handle amount2Label visibility
-        Assembly baselib = null; // ModManager.GetLoadedMods().First(mod => mod.manifest?.id == BaseLib.BaseLibMain.ModId).assembly; // TODO: Removed this no idea how to fix
-        if (baselib?.GetType("BaseLib.Abstracts.ITwoAmountPower") == null) {
+        var baselib = typeof(BaseLib.BaseLibMain).Assembly;
+        if (baselib.GetType("BaseLib.Abstracts.ITwoAmountPower") == null) {
             amount2Label.Visible = false;
         }
         DisplaySecondAmount.TryGetValue(__instance.Model.GetType(), out var func);
@@ -162,8 +161,14 @@ static class TwoAmountPowers
         static void CallRefreshAmount(PowerModel __instance)
         {
             doNotFlashOnAmountRefresh = true;
-            __instance.InvokeDisplayAmountChanged();
-            doNotFlashOnAmountRefresh = true;
+            try
+            {
+                __instance.InvokeDisplayAmountChanged();
+            }
+            finally
+            {
+                doNotFlashOnAmountRefresh = false;
+            }
         }
         
         [HarmonyTargetMethods]
@@ -175,7 +180,6 @@ static class TwoAmountPowers
                 typeof(JugglingPower).Method(nameof(JugglingPower.AfterApplied)),
                 typeof(JugglingPower).Method(nameof(JugglingPower.AfterCardPlayed)),
                 typeof(JugglingPower).Method(nameof(JugglingPower.AfterSideTurnEnd)),
-                typeof(PaleBlueDotPower).Method(nameof(PaleBlueDotPower.ModifyHandDraw)),
                 typeof(ToricToughnessPower).Method(nameof(ToricToughnessPower.SetBlock)),
                 typeof(InfernoPower).Method(nameof(InfernoPower.IncrementSelfDamage)),
                 typeof(CrimsonMantlePower).Method(nameof(CrimsonMantlePower.IncrementSelfDamage)),
@@ -189,7 +193,7 @@ static class TwoAmountPowers
                 { typeof(Hook).Method(nameof(Hook.AfterCardPlayed)).PatchAsync(), [typeof(PaleBlueDotPower)] },
                 { typeof(Hook).Method(nameof(Hook.AfterPowerAmountChanged)).PatchAsync(), [typeof(VulnerablePower), typeof(WeakPower)] },
                 { typeof(Hook).Method(nameof(Hook.AfterBlockGained)).PatchAsync(), [typeof(UnmovablePower)] },
-                { typeof(Hook).Method(nameof(Hook.AfterPlayerTurnStart)).PatchAsync(), [typeof(UnmovablePower)] },
+                { typeof(Hook).Method(nameof(Hook.AfterPlayerTurnStart)).PatchAsync(), [typeof(UnmovablePower), typeof(PaleBlueDotPower)] },
             };
         
             private static void AfterHook(AbstractModel model, MethodBase method)
@@ -260,4 +264,3 @@ static class TwoAmountPowers
         return true;
     }
 }
-*/


### PR DESCRIPTION
## Summary

This PR fixes `TwoAmountPowers` after the latest game update (v0.108.0).

The old `PaleBlueDotPower.ModifyHandDraw` patch target is no longer valid in the current game version. `PaleBlueDotPower` no longer declares that override, so the method lookup can resolve to the inherited `AbstractModel.ModifyHandDraw` instead. That means Harmony may patch the base hook method and `CallRefreshAmount(PowerModel __instance)` can receive non-power models during combat turn setup, which can lead to an invalid call path and a crash.

The fix removes that stale patch target, refreshes Pale Blue Dot from the hook path instead, and changes the Pale Blue Dot display counter to use `HappenedThisTurn(...)` so it resets correctly across turn/side changes. It also fixes `doNotFlashOnAmountRefresh` so the flag is restored with `try/finally`.

This also restores the BaseLib assembly lookup. MintySpire already directly depends on BaseLib and directly references `BaseLib.BaseLibMain`, so the code can use:
```csharp
var baselib = typeof(BaseLib.BaseLibMain).Assembly;
```
instead of trying to rediscover the loaded mod assembly indirectly.

## Follow-up Suggestion

To avoid this kind of issue in future game updates, a helper can be added for Harmony targets that must be declared directly on the target type to avoid removed overrides silently resolving to a base class method and patching an unintended surface. Example:

```csharp
private static MethodInfo? DeclaredMethod(Type type, string name, params Type[] parameters)
{
    return type.GetMethod(
        name,
        BindingFlags.Instance
            | BindingFlags.Public
            | BindingFlags.NonPublic
            | BindingFlags.DeclaredOnly,  // <<- this
        binder: null,
        types: parameters,
        modifiers: null
    );
}
```

For optional UI refresh patches, missing methods can be skipped:

```csharp
foreach (var method in new MethodBase?[] {
    DeclaredMethod(typeof(VoidFormPower), nameof(VoidFormPower.AfterCardPlayed), typeof(PlayerChoiceContext), typeof(CardPlay)),
    DeclaredMethod(typeof(JugglingPower), nameof(JugglingPower.AfterCardPlayed), typeof(PlayerChoiceContext), typeof(CardPlay)),
}) {
    if (method != null) {
        yield return method;
    }
}
```

This would make future update breakage fail closed instead of accidentally patching inherited base methods.