### PR TITLE
fix: Remove heal text when button is clicked

### DIFF
--- a/MintySpire2Code/RestHPRender.cs
+++ b/MintySpire2Code/RestHPRender.cs
@@ -46,6 +46,24 @@ public static class RestHPRender
         CreateLabelIfNotExists(__instance);
         UpdateExtraLabel(__instance);
     }
+    
+    /// <summary>
+    ///     After NRestSiteButton is pressed, immediately hide the text.
+    ///     Remove child instead of just setting visible to false because CatchHPChange revisibles it
+    /// </summary>
+    [HarmonyPatch(typeof(NRestSiteButton), "OnPress")]
+    [HarmonyPostfix]
+    public static void OnPress_Postfix(NRestSiteButton __instance)
+    {
+        if (__instance.Option is not HealRestSiteOption) return;
+
+        var parent = __instance.GetNodeOrNull<Control>("%Visuals") ?? __instance;
+        var label = parent.FindChild(HealLabelNodeName, true, false)  as Label;
+
+        if (label != null)
+            parent.RemoveChild(label);
+    }
+
 
     /// <summary>
     ///     Creates the label and applies layout/styling. Uses %Visuals as the parent when available.


### PR DESCRIPTION
It bothered me that when you clicked the heal button the text above would update with the amount you healed to during the cloudy animation. This removes the entire label once the button is clicked. The `CatchHPChange` patch would catch the HP updating and immediately make the label visible again if I just tried to set `visible` to `false`. I think removing it completely is safe because anything that cares about the label existing checks if one exists and makes one if it doesn't.